### PR TITLE
Conserta URL do git cheat sheet

### DIFF
--- a/_posts/2013-04-14-github.md
+++ b/_posts/2013-04-14-github.md
@@ -119,5 +119,5 @@ Se quiser continuar fazendo alterações e as enviando para o GitHub, você prec
 ### Aprenda mais sobre Git
 
  * Confira [trygit.org](http://try.github.io/)
- * Use um [Git Cheatsheet](https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf)
+ * Use um [Git Cheatsheet](https://github.github.com/training-kit/downloads/pt_BR/github-git-cheat-sheet/) ([PDF](https://github.github.com/training-kit/downloads/pt_BR/github-git-cheat-sheet.pdf))
  * Veja outros comandos Git em [git-scm.org](http://git-scm.com/)


### PR DESCRIPTION
#91 

Altera a URL do git cheat sheet como feito no repo em inglês mas referenciando os links em português BR